### PR TITLE
fix: Invalid date on page change

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -85,22 +85,19 @@
 
 <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" type="text/javascript"></script>
 <script>
+  function localizeDate(page) {
+    const startTimes = document.getElementsByClassName('startTime')
+    for (const startTime of startTimes) {
+      const dateString = startTime.data.trim()
+      startTime.textContent = new Date(dateString).toLocaleString()
+    }
+  }
   const dataTable = new simpleDatatables.DataTable("#contest-table", {
     searchable: true,
     fixedHeight: true,
     sortable: false,
   });
 
-  const contests = document.getElementsByClassName('startTime')
-  for (let contest of contests) {
-    let startTime = new Date(contest.textContent)
-    contest.textContent = startTime.toLocaleString()
-  }
-  dataTable.on('datatable.page', function (page) {
-    const contests = document.getElementsByClassName('startTime')
-    for (let contest of contests) {
-      let startTime = new Date(contest.textContent)
-      contest.textContent = startTime.toLocaleString()
-    }
-  })
+  localizeDate()
+  dataTable.on('datatable.page', localizeDate)
 </script>


### PR DESCRIPTION
Currently, contest start time is displayed correctly on the first page load. Whenever the page is changed, either `Invalid Date` is displayed, or an incorrect date (with day and month swapped) is displayed. This happens for locales using DD/MM/YYYY instead of MM/DD/YYYY.

On first page load:
![Screenshot 2021-10-31 at 11 01 53 AM](https://user-images.githubusercontent.com/8776011/139569480-0489c8ed-0ee6-4468-a763-70487e439bf5.jpg)

After page change:
![Screenshot 2021-10-31 at 11 06 02 AM](https://user-images.githubusercontent.com/8776011/139569559-cdd3ef6c-342c-4469-ad6c-324552819e4e.jpg)

