### PR TITLE
Fixes accordion overlapping elements below it on Homepage

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -159,6 +159,7 @@ td {
     font-weight: 300;
     max-height: 0;
     opacity: 0;
+    overflow: hidden;
     color: var(--color-text-muted);
     transform: translateX(16px);
     transition: max-height 0.5s ease, opacity 0.5s, transform 0.5s;


### PR DESCRIPTION
Only keeping opacity 0 doesn't hide the content. In this case the single accordion was messing with elements below it. Simple fix of it is to keep overflow hidden.